### PR TITLE
hotfix: 목업 파일 불러오기 - 불필요 코드 삭제, pathvariable 버그 수정

### DIFF
--- a/src/main/java/com/evenly/evenide/mock/MockFileController.java
+++ b/src/main/java/com/evenly/evenide/mock/MockFileController.java
@@ -10,20 +10,6 @@ import java.util.Map;
 @RequestMapping("/mock")
 public class MockFileController {
 
-    @GetMapping("/file")
-    public ResponseEntity<?> getFile() {
-        Map<String, Object> file = Map.of(
-                        "fileId", "f001",
-                        "name", "main.py",
-                        "content", "print('Hello')",
-                        "updatedAt", "2025-04-07T11:00:00Z",
-                        "isLocked", false,
-                        "isEditLocked", false
-                );
-
-        return ResponseEntity.ok(file);
-    }
-
     @PostMapping("/file")
     public ResponseEntity<?> createFile(@RequestBody Map<String, String> req) {
         return ResponseEntity.ok(Map.of(
@@ -55,7 +41,7 @@ public class MockFileController {
     }
 
     @GetMapping("/file/{fileId}")
-    public ResponseEntity<?> accessFile(@PathVariable String projectId, @PathVariable String fileId) {
+    public ResponseEntity<?> accessFile(@PathVariable String fileId) {
         return ResponseEntity.ok(Map.of(
                 "fileId", fileId,
                 "name", "main.py",


### PR DESCRIPTION
## 📌 작업 개요
- 목업 API GET 단건 파일 코드 수정

---

## ✨ 주요 변경 사항
- 목업 API GET 단건 파일 코드 수정 - 프로젝트 관리를 고려한 코드가 있었습니다. 
    - @PathVariable String projectId 삭제
---

## 🖼️ 화면(또는 기능) 미리 보기 (선택)
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] log.info / 불필요한 주석 제거
---
