### PR TITLE
회원가입 닉네임 중복 방지 예외 추가

### DIFF
--- a/src/main/java/com/evenly/evenide/Config/Security/SecurityConfig.java
+++ b/src/main/java/com/evenly/evenide/Config/Security/SecurityConfig.java
@@ -8,6 +8,8 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -49,5 +51,10 @@ public class SecurityConfig {
 
         source.registerCorsConfiguration("/**", configuration);
         return source;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/main/java/com/evenly/evenide/entity/User.java
+++ b/src/main/java/com/evenly/evenide/entity/User.java
@@ -28,7 +28,7 @@ public class User {
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String nickname;
 
     @CreatedDate

--- a/src/main/java/com/evenly/evenide/service/AuthService.java
+++ b/src/main/java/com/evenly/evenide/service/AuthService.java
@@ -23,6 +23,11 @@ public class AuthService {
             throw new CustomException(ErrorCode.EMAIL_ALREADY_EXISTS);
         }
 
+        // 닉네임 중복 확인
+        if (userRepository.existsByNickname(signUpDto.getNickname())) {
+            throw new CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+        }
+
         // 비밀번호 암호화
         String encodedPassword = passwordEncoder.encode(signUpDto.getPassword());
 


### PR DESCRIPTION
## 📌 작업 개요
- 어떤 작업을 했는지 한 줄 요약
  - ex: 회원가입 API 수정 ( 닉네임 중복 )

---

## ✨ 주요 변경 사항
- 회원가입 시 닉네임 중복 예외 처리 추가

---

## 🖼️ 화면(또는 기능) 미리 보기 (선택)
> 회원가입 요청 정보 (예시)
![스크린샷 2025-04-10 오전 12 46 07](https://github.com/user-attachments/assets/a6c86e59-9477-486a-b1aa-87677e6f6da7)

**회원가입 닉네임 중복시**
![스크린샷 2025-04-10 오전 12 38 24](https://github.com/user-attachments/assets/c7459aaa-bc88-4441-b40a-5e1b86da54c8)

**회원가입 이메일 중복시**
![스크린샷 2025-04-10 오전 12 38 38](https://github.com/user-attachments/assets/602cb94e-006f-429b-aa93-ee199b5c8086)


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] SecurityConfig 파일 암호화 코드 추가 ( 패스워드 부분 ) --> mysql 워크밴치로 db 확인시 암호화되어서 나타납니다.

---

## 💬 기타 참고 사항
- 이메일은 중복확인을 했었는데 닉네임을 안했었습니다.. 테스트 하다 발견했어요😳 죄송합니다..🙇‍♀️

---

