### PR TITLE
파일, 코드수정 잠금 해제 목업 API 수정

### DIFF
--- a/src/main/java/com/evenly/evenide/mock/MockFileController.java
+++ b/src/main/java/com/evenly/evenide/mock/MockFileController.java
@@ -3,6 +3,7 @@ package com.evenly.evenide.mock;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -108,23 +109,30 @@ public class MockFileController {
         return ResponseEntity.ok(Map.of("message", "success"));
     }
 
-    @PostMapping("/projects/{projectId}/files/{fileId}/lock")
-    public ResponseEntity<?> lockFile(@PathVariable String projectId, @PathVariable String fileId) {
+    private Map<String, Map<String, Boolean>> fileLockStatus = new HashMap<>();
+    private Map<String, Map<String, Boolean>> fileEditLockStatus = new HashMap<>();
+
+    @PatchMapping("/projects/{projectId}/files/{fileId}/lock")
+    public ResponseEntity<?> lockUnlockFile(
+            @PathVariable String projectId,
+            @PathVariable String fileId) {
+        fileLockStatus.putIfAbsent(projectId, new HashMap<>());
+        Boolean isLocked = fileLockStatus.get(projectId).getOrDefault(fileId, false);
+        isLocked = !isLocked;
+        fileLockStatus.get(projectId).put(fileId, isLocked);
         return ResponseEntity.ok(Map.of("message", "success"));
     }
 
-    @PostMapping("/projects/{projectId}/files/{fileId}/unlock")
-    public ResponseEntity<?> unlockFile(@PathVariable String projectId, @PathVariable String fileId) {
-        return ResponseEntity.ok(Map.of("message", "success"));
-    }
+    @PatchMapping("/projects/{projectId}/files/{fileId}/edit/lock")
+    public ResponseEntity<?> lockUnlockEdit(
+            @PathVariable String projectId,
+            @PathVariable String fileId) {
 
-    @PostMapping("/projects/{projectId}/files/{fileId}/edit/lock")
-    public ResponseEntity<?> lockEdit(@PathVariable String projectId, @PathVariable String fileId) {
-        return ResponseEntity.ok(Map.of("message", "success"));
-    }
+        fileEditLockStatus.putIfAbsent(projectId, new HashMap<>());
+        Boolean isLocked = fileEditLockStatus.get(projectId).getOrDefault(fileId, false);
+        isLocked = !isLocked;
+        fileEditLockStatus.get(projectId).put(fileId, isLocked);
 
-    @PostMapping("/projects/{projectId}/files/{fileId}/edit/unlock")
-    public ResponseEntity<?> unlockEdit(@PathVariable String projectId, @PathVariable String fileId) {
         return ResponseEntity.ok(Map.of("message", "success"));
     }
 }


### PR DESCRIPTION
## 📌 작업 개요
- 파일, 코드수정 잠금 해제 목업 API 수정

---

## ✨ 주요 변경 사항
- POST로 파일 잠금/해제, 코드 수정 잠금/해제 2개씩 나눠있던 API를 PATCH로 스위치 되도록 수정했습니다.
- 응답은 프론트와 논의를 통해 `{"message": "success"}` 로 결정지어 별도의 잠금, 해제 표시 없이 통일했습니다.

---

## 🖼️ 화면(또는 기능) 미리 보기 (선택)
![image](https://github.com/user-attachments/assets/b614a652-1f33-4c28-92b9-cfded6a89530)
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- 목업이라 다른 작업은 없습니다.

---

목업 API는 찐찐막이길...