### PR TITLE
코드 실행 API 구현

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     depends_on:
       - db
       - redis
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   redis:
     image: redis:latest

--- a/src/main/java/com/evenly/evenide/Config/AppConfig.java
+++ b/src/main/java/com/evenly/evenide/Config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.evenly.evenide.Config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/evenly/evenide/Config/Security/SecurityConfig.java
+++ b/src/main/java/com/evenly/evenide/Config/Security/SecurityConfig.java
@@ -32,6 +32,7 @@ public class SecurityConfig {
                         .requestMatchers("/auth/**").permitAll() // 로그인, 회원가입 인증 없이
                         .requestMatchers(HttpMethod.GET, "/projects/*", "/projects/*/files/*").permitAll() // 프로젝트, 파일 단건 조회 인증 없이
                         .requestMatchers(HttpMethod.PATCH, "/projects/*/files/*/code").permitAll() // 코드 수정 인증 없이
+                        .requestMatchers(HttpMethod.POST, "/code/execute").permitAll()// 코드 실행 인증 없이
                         .anyRequest().authenticated() // 그외 모든 요청은 인증 필요
                 )
                 .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/evenly/evenide/controller/CodeRunController.java
+++ b/src/main/java/com/evenly/evenide/controller/CodeRunController.java
@@ -1,0 +1,25 @@
+package com.evenly.evenide.controller;
+
+import com.evenly.evenide.dto.CodeExecutionRequestDto;
+import com.evenly.evenide.dto.CodeExecutionResponse;
+import com.evenly.evenide.service.CodeRunService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/code")
+public class CodeRunController {
+
+    private final CodeRunService codeRunService;
+
+    @PostMapping("/execute")
+    public ResponseEntity<CodeExecutionResponse> runCode(@RequestBody CodeExecutionRequestDto requestDto) {
+        String result = codeRunService.runCode(requestDto.getLanguage(), requestDto.getContent());
+        return ResponseEntity.ok(new CodeExecutionResponse(result));
+    }
+}

--- a/src/main/java/com/evenly/evenide/controller/FileController.java
+++ b/src/main/java/com/evenly/evenide/controller/FileController.java
@@ -66,7 +66,7 @@ public class FileController {
     public ResponseEntity<EditorFileResponse> updateCode(
             @PathVariable Long projectId,
             @PathVariable Long fileId,
-            @RequestBody @Valid CodeUpdateRequestDto requestDto
+            @RequestBody @Valid CodeExecutionRequestDto requestDto
     ) {
         EditorFileResponse response = fileService.updateCode(projectId, fileId, requestDto);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/evenly/evenide/dto/CodeExecutionRequestDto.java
+++ b/src/main/java/com/evenly/evenide/dto/CodeExecutionRequestDto.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class CodeUpdateRequestDto {
+public class CodeExecutionRequestDto {
 
     @NotBlank
     private String language;

--- a/src/main/java/com/evenly/evenide/dto/CodeExecutionResponse.java
+++ b/src/main/java/com/evenly/evenide/dto/CodeExecutionResponse.java
@@ -1,0 +1,12 @@
+package com.evenly.evenide.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CodeExecutionResponse {
+    private String result;
+}

--- a/src/main/java/com/evenly/evenide/service/CodeRunService.java
+++ b/src/main/java/com/evenly/evenide/service/CodeRunService.java
@@ -1,0 +1,28 @@
+package com.evenly.evenide.service;
+
+import com.evenly.evenide.dto.CodeExecutionRequestDto;
+import com.evenly.evenide.dto.CodeExecutionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+public class CodeRunService {
+
+    private final RestTemplate restTemplate;
+
+    public String runCode(String language, String content) {
+        String url = "http://host.docker.internal:8081/code/execute";
+
+        CodeExecutionRequestDto requestDto = new CodeExecutionRequestDto(language, content);
+
+        ResponseEntity<CodeExecutionResponse> response = restTemplate.postForEntity(
+                url,
+                requestDto,
+                CodeExecutionResponse.class
+        );
+        return response.getBody().getResult();
+    }
+}

--- a/src/main/java/com/evenly/evenide/service/FileService.java
+++ b/src/main/java/com/evenly/evenide/service/FileService.java
@@ -102,7 +102,7 @@ public class FileService {
 
     //코드 수정 - 로그인/비로그인
     @Transactional
-    public EditorFileResponse updateCode(Long projectId, Long fileId, CodeUpdateRequestDto requestDto) {
+    public EditorFileResponse updateCode(Long projectId, Long fileId, CodeExecutionRequestDto requestDto) {
         CodeFile file = fileRepository.findById(fileId)
                 .orElseThrow(() -> new CustomException(ErrorCode.FILE_NOT_FOUND));
 


### PR DESCRIPTION
## 📌 작업 개요
- 코드 실행 API 구현

---

## ✨ 주요 변경 사항
- 코드 실행 API 구현
    - java, js, python 실행 가능

---

## 🖼️ 화면(또는 기능) 미리 보기 (선택)
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

|자바|자바스크립트|파이썬|
|-----|------|------|
|![image](https://github.com/user-attachments/assets/7e057d3d-c985-49cf-8850-83d9bbaf59fc)|![image](https://github.com/user-attachments/assets/7ae55bcc-fa0c-455f-8672-c6fd0b3bff88)|![image](https://github.com/user-attachments/assets/b51d325d-2c34-435d-8e43-3cadb3a66cb4)|


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [ ] 기능별 예외 케이스 고려 -> 위험 코드 등 추가 필요
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 💬 기타 참고 사항
- 기존 evenide-back 프로젝트의 스프링이 도커에서 실행되기 때문에, 도커 run으로 코드를 실행시키면 docker in docker 가 되어 보안, 권한, 성능 문제가 있어서 별도의 레포(관련 문서 참고)로 서버에 배포 후 서버에서 스프링을 jar로 실행시켜 놨습니다. 
- 결과 저장 등 기능 확장의 가능성을 열어놓고자 8080 API를 거쳐서 코드 실행 될 수 있도록 RestTemplate으로 8081 포트 불러서 사용할 수 있도록 API 구현했습니다.

---

## 📎 관련 이슈 / 문서
- https://github.com/code-is-evenly-cooked/even-IDE-coderunner
