### PR TITLE
비밀번호 재설정 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
       SPRING_REDIS_HOST: ${REDIS_HOST}
       SPRING_REDIS_PORT: ${REDIS_PORT}
       SPRING_REDIS_PASSWORD: ${REDIS_PASSWORD}
+      RESET_URL: ${RESET_URL}
+
     ports:
       - "8080:8080"
     depends_on:

--- a/src/main/java/com/evenly/evenide/controller/AuthController.java
+++ b/src/main/java/com/evenly/evenide/controller/AuthController.java
@@ -1,9 +1,7 @@
 package com.evenly.evenide.controller;
 
 import com.evenly.evenide.Config.Security.JwtUtil;
-import com.evenly.evenide.dto.SignInDto;
-import com.evenly.evenide.dto.SignUpDto;
-import com.evenly.evenide.dto.SignUpResponse;
+import com.evenly.evenide.dto.*;
 import com.evenly.evenide.entity.User;
 import com.evenly.evenide.global.response.MessageResponse;
 import com.evenly.evenide.repository.RefreshTokenRepository;
@@ -69,4 +67,12 @@ public class AuthController {
         refreshTokenRepository.deleteById(Long.valueOf(userId));
         return ResponseEntity.ok(new MessageResponse("success"));
     }
+
+    @PostMapping("/forgot-password")
+    public ResponseEntity<MessageResponse> forgotPassword(@RequestBody EmailRequestDto userInfoDto){
+        authService.sendResetEmail(userInfoDto.getEmail());
+        return ResponseEntity.ok(new MessageResponse("success"));
+    }
+
+
 }

--- a/src/main/java/com/evenly/evenide/controller/AuthController.java
+++ b/src/main/java/com/evenly/evenide/controller/AuthController.java
@@ -69,10 +69,15 @@ public class AuthController {
     }
 
     @PostMapping("/forgot-password")
-    public ResponseEntity<MessageResponse> forgotPassword(@RequestBody EmailRequestDto userInfoDto){
+    public ResponseEntity<MessageResponse> forgotPassword(@RequestBody @Valid EmailRequestDto userInfoDto){
         authService.sendResetEmail(userInfoDto.getEmail());
         return ResponseEntity.ok(new MessageResponse("success"));
     }
 
+    @PostMapping("/password-reset")
+    public ResponseEntity<MessageResponse> resetPassword(@RequestBody @Valid PasswordResetRequestDto requestDto){
+        authService.resetPassword(requestDto.getToken(), requestDto.getNewPassword());
+        return ResponseEntity.ok(new MessageResponse("success"));
+    }
 
 }

--- a/src/main/java/com/evenly/evenide/dto/EmailRequestDto.java
+++ b/src/main/java/com/evenly/evenide/dto/EmailRequestDto.java
@@ -1,0 +1,10 @@
+package com.evenly.evenide.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class EmailRequestDto {
+    private String email;
+}

--- a/src/main/java/com/evenly/evenide/dto/EmailRequestDto.java
+++ b/src/main/java/com/evenly/evenide/dto/EmailRequestDto.java
@@ -1,10 +1,20 @@
 package com.evenly.evenide.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
 public class EmailRequestDto {
+
+    @Email(message = "올바른 이메일을 입력해주세요.")
+    @Pattern(
+            regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$",
+            message = "올바른 이메일 형식을 입력해주세요."
+    )
+    @NotBlank(message = "이메일은 필수 입력 값입니다.")
     private String email;
 }

--- a/src/main/java/com/evenly/evenide/dto/PasswordResetRequestDto.java
+++ b/src/main/java/com/evenly/evenide/dto/PasswordResetRequestDto.java
@@ -1,0 +1,17 @@
+package com.evenly.evenide.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PasswordResetRequestDto {
+    private String token;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Pattern(regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*\\d)(?=.*[_!@#$%^&*])[A-Za-z\\d_!@#$%^&*]{6,}$",
+            message ="비밀번호는 대문자, 소문자, 숫자, 특수문자를 포함한 6자 이상이어야 합니다.")
+    private String newPassword;
+}

--- a/src/main/java/com/evenly/evenide/entity/PasswordResetToken.java
+++ b/src/main/java/com/evenly/evenide/entity/PasswordResetToken.java
@@ -1,0 +1,31 @@
+package com.evenly.evenide.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordResetToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiration;
+
+    @OneToOne
+    @JoinColumn(name = "user_Id", nullable = false, unique = true)
+    private User user;
+}

--- a/src/main/java/com/evenly/evenide/global/exception/ErrorCode.java
+++ b/src/main/java/com/evenly/evenide/global/exception/ErrorCode.java
@@ -10,6 +10,8 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "가입되지 않은 사용자 입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "Refresh token이 만료되었습니다. 다시 로그인하세요."),
+    INVALID_PASSWORD_RESET_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 비밀번호 재설정 토큰입니다."),
+    EXPIRED_PASSWORD_RESET_TOKEN(HttpStatus.BAD_REQUEST, "만료된 비밀번호 재설정 토큰입니다."),
 
     PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "프로젝트를 찾을 수 없습니다."),
     PROJECT_OWNER_NOT_YOU(HttpStatus.FORBIDDEN,"프로젝트 주인이 아닙니다."),

--- a/src/main/java/com/evenly/evenide/repository/PasswordResetTokenRepository.java
+++ b/src/main/java/com/evenly/evenide/repository/PasswordResetTokenRepository.java
@@ -1,0 +1,13 @@
+package com.evenly.evenide.repository;
+
+import com.evenly.evenide.entity.PasswordResetToken;
+import com.evenly.evenide.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
+    Optional<PasswordResetToken> findByToken(String token);
+
+    void deleteByUser(User user);
+}

--- a/src/main/java/com/evenly/evenide/service/AuthService.java
+++ b/src/main/java/com/evenly/evenide/service/AuthService.java
@@ -184,7 +184,7 @@ public class AuthService {
 
         // 기존 토큰 삭제
         passwordResetTokenRepository.deleteByUser(user);
-
+        passwordResetTokenRepository.flush();
         // 토큰 생성
         String token = UUID.randomUUID().toString();
 

--- a/src/main/java/com/evenly/evenide/service/AuthService.java
+++ b/src/main/java/com/evenly/evenide/service/AuthService.java
@@ -13,6 +13,7 @@ import com.evenly.evenide.repository.PasswordResetTokenRepository;
 import com.evenly.evenide.repository.RefreshTokenRepository;
 import com.evenly.evenide.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,6 +32,9 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordResetTokenRepository passwordResetTokenRepository;
     private final EmailService emailService;
+
+    @Value("${app.reset.url}")
+    private String resetBaseUrl;
 
     public User signup(SignUpDto signUpDto) {
 
@@ -197,7 +201,7 @@ public class AuthService {
 
         passwordResetTokenRepository.save(resetToken);
 
-        String resetUrl = "http://localhost:8080/reset-password?token=" + token;    // 배포때 주소 수정 필요함(현재는 로컬이라 괜찮습니다.)
+        String resetUrl = resetBaseUrl + "/reset-password?token=" + token;
         emailService.sendResetPasswordEmail(user.getEmail(), resetUrl);
 
     }

--- a/src/main/java/com/evenly/evenide/service/EmailService.java
+++ b/src/main/java/com/evenly/evenide/service/EmailService.java
@@ -1,0 +1,28 @@
+package com.evenly.evenide.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EmailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendResetPasswordEmail(String to, String resetUrl){
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject("[even ide] 비밀번호 재설정 링크 입니다.");
+        message.setText("""
+                안녕하세요. even ide 입니다.
+                
+                아래 링크를 클릭하시면 비밀번호를 재설정 하실 수 있습니다.
+                %s
+                해당 링크는 10분 동안만 유효합니다.
+                감사합니다!
+                """.formatted(resetUrl));
+        mailSender.send(message);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,3 +24,11 @@ spring.jpa.properties.hibernate.type.descriptor.sql.BasicBinder.log=true
 jwt.secret=${JWT_SECRET}
 jwt.refresh_secret=${JWT_REFRESH_SECRET}
 jwt.expiration_time=${JWT_EXPIRATION_TIME}
+
+# Mail
+spring.mail.host=smtp.gmail.com
+spring.mail.port=587
+spring.mail.username=${MAIL_USERNAME}
+spring.mail.password=${MAIL_PASSWORD}
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -30,5 +30,6 @@ spring.mail.host=smtp.gmail.com
 spring.mail.port=587
 spring.mail.username=${MAIL_USERNAME}
 spring.mail.password=${MAIL_PASSWORD}
+app.reset.url=${RESET_URL}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true


### PR DESCRIPTION
## 📌 작업 개요
- 비밀번호 재설정 API 구현

---

## ✨ 주요 변경 사항
- POST /auth/forgot-password - 이메일 인증 요청
- POST /auth/reset-password - 토큰 기반 비밀번호 재설정

---

## 🖼️ 화면(또는 기능) 미리 보기 (선택)
> 포스트맨 요청 응답 스크린샷

| 비밀번호 재설정 성공 (링크 발송) | 비밀번호 재설정시 등록되지 않은 사용자일때(링크 발송) | 비밀번호 재설정시 형식 틀렸을때(링크 발송) | 
|---------|-----------------|-------------|
|![비밀번호 재설정(링크) 성공했을때](https://github.com/user-attachments/assets/193c6940-872e-4a15-90f9-e61edaaebf9b)|![비밀번호 재설정(링크) 가입없을떄](https://github.com/user-attachments/assets/df5c7656-aa23-4a06-9f91-69b1fd9ccd4d)|![비밀번호 재설정(링크) 형식 틀렸을때](https://github.com/user-attachments/assets/23e3b8c5-49ec-4ee7-9057-1d4afcd3eab9)|



<div align="center">
<strong>이메일 링크 발송 성공 시</strong>  
<br>
  <img src="https://github.com/user-attachments/assets/ed06f30c-7163-4537-8b1e-31e49e19924f" width="400" height="300" alt="이메일 링크 확인" />
</div>


| 비밀번호 변경 후 형식 틀렸을때 | 비밀번호 재설정 성공 | 로그인 (새로운 비번 입력시) | 
|---------|-----------------|-------------|
|![비밀번호 재설정 형식 틀렸을때](https://github.com/user-attachments/assets/f53c71b7-2947-49ab-bfa4-0a5e0795f79d)|![비밀번호 재설정 성공](https://github.com/user-attachments/assets/809c97a0-c745-4aa8-8cc8-4c2e19e61513)|![비밀번호 재설정 바뀐 비번 성공시](https://github.com/user-attachments/assets/00fbb914-2d9f-4573-b95a-84bcb2d6cec8)|


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 토큰 생성 및 저장,삭제 (jwt아니고 uuid기반 입니다.)
- [x] 예외 처리
- [x] 토큰 기반 비밀번호 재설정

---

## 💬 기타 참고 사항

- **비밀번호 재설정 시, 요청주셨던 userId 또는 email 기반 직접 인증 방식 대신 UUID 기반 토큰 인증 방식을 적용하였습니다.** (보안 문제)
- 현재는 포스트맨에서만 테스트 하는거라 이메일에 날아오는 token을 복붙해야 변경이 가능합니다.
- 메일 관련 .env 추가 있습니다. 디코로 드리겠습니다!


---

