### PR TITLE
hotfix 로그인 응답 요청사항 수정

### DIFF
--- a/src/main/java/com/evenly/evenide/controller/AuthController.java
+++ b/src/main/java/com/evenly/evenide/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.evenly.evenide.controller;
 
 import com.evenly.evenide.Config.Security.JwtUtil;
 import com.evenly.evenide.dto.SignInDto;
+import com.evenly.evenide.dto.SignInResponse;
 import com.evenly.evenide.dto.SignUpDto;
 import com.evenly.evenide.dto.SignUpResponse;
 import com.evenly.evenide.entity.User;
@@ -9,7 +10,6 @@ import com.evenly.evenide.global.response.MessageResponse;
 import com.evenly.evenide.repository.RefreshTokenRepository;
 import com.evenly.evenide.service.AuthService;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -47,16 +47,15 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<Map<String, String>> login(@RequestBody @Valid SignInDto signInDto, HttpServletResponse response){
-        Map<String, String> tokens = authService.login(signInDto);
-        return ResponseEntity.ok(tokens);
+    public ResponseEntity<SignInResponse> login(@RequestBody @Valid SignInDto signInDto){
+        return ResponseEntity.ok(authService.login(signInDto));
 
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<Map<String,String>> refreshToken(@RequestHeader("Authorization")String token){
+    public ResponseEntity<SignInResponse> refreshToken(@RequestHeader("Authorization")String token){
         String refreshToken = jwtUtil.resolveToken(token);
-        Map<String, String> newTokens = authService.refresh(refreshToken);
+        SignInResponse newTokens = authService.refresh(refreshToken);
         return ResponseEntity.ok(newTokens);
     }
 

--- a/src/main/java/com/evenly/evenide/dto/SignInResponse.java
+++ b/src/main/java/com/evenly/evenide/dto/SignInResponse.java
@@ -1,0 +1,13 @@
+package com.evenly.evenide.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+@Getter
+@AllArgsConstructor
+public class SignInResponse {
+    private String accessToken;
+    private String refreshToken;
+    private Long userId;
+    private String nickname;
+    private String provider;
+}


### PR DESCRIPTION
## 📌 작업 개요
- 로그인 응답 요청사항 수정

---

## ✨ 주요 변경 사항
- 로그인 응답 요청사항 수정
   - 기존 accessToken, refreshToken 에서 accessToken, refreshToken, userId(Long), nickname, provider 로 변경
---

## 🖼️ 화면(또는 기능) 미리 보기 (선택)
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능
![image](https://github.com/user-attachments/assets/27fe26f7-3763-496a-a1bf-9b429ce8a136)
![image](https://github.com/user-attachments/assets/4d00b506-8b17-4fa8-b9db-0c7f832edbce)

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 💬 기타 참고 사항
- refreshToken 부분에서 db에 저장된 토큰이랑 로그인 후 주는 토큰이 달라서 검증 부분에서 에러가 났습니다. 
- 에러 해결을 위해 로그인시에 계속 변경 되도록 로그인 부분에 @Transactional 추가 했습니다.
- 로그인시 변경 되는 부분, 프론트에서 ok 했습니다.

---

## 📎 관련 이슈 / 문서
<img width="628" alt="image" src="https://github.com/user-attachments/assets/623b548b-98ba-452e-abf1-c893023f519b" />

