### PR TITLE
메시지 검색 및 앞뒤 컨텍스트 메시지 조회 API 구현

### DIFF
--- a/src/main/java/com/evenly/evenide/controller/ChatApiController.java
+++ b/src/main/java/com/evenly/evenide/controller/ChatApiController.java
@@ -84,8 +84,18 @@ public class ChatApiController {
     public ResponseEntity<List<ChatMessage>> searchMessage(
             @RequestParam String projectId,
             @RequestParam String keyword,
-            @AuthenticationPrincipal JwtUserInfoDto userInfo
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto
     ) {
         return ResponseEntity.ok(chatService.searchMessages(projectId, keyword));
     }
+
+    @GetMapping("/context")
+    public ResponseEntity<List<ChatMessage>> getContext(
+            @RequestParam String projectId,
+            @RequestParam String timestamp,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto
+    ) {
+        return ResponseEntity.ok(chatService.getContext(projectId, timestamp));
+    }
+
 }

--- a/src/main/java/com/evenly/evenide/controller/ChatApiController.java
+++ b/src/main/java/com/evenly/evenide/controller/ChatApiController.java
@@ -79,4 +79,13 @@ public class ChatApiController {
     ) {
         return ResponseEntity.ok(chatService.getRedisMessages(projectId, jwtUtil.resolveToken(token)));
     }
+
+    @GetMapping("/search")
+    public ResponseEntity<List<ChatMessage>> searchMessage(
+            @RequestParam String projectId,
+            @RequestParam String keyword,
+            @AuthenticationPrincipal JwtUserInfoDto userInfo
+    ) {
+        return ResponseEntity.ok(chatService.searchMessages(projectId, keyword));
+    }
 }

--- a/src/main/java/com/evenly/evenide/service/ChatService.java
+++ b/src/main/java/com/evenly/evenide/service/ChatService.java
@@ -11,6 +11,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -97,7 +98,10 @@ public class ChatService {
     public List<ChatMessage> searchMessages(String projectId, String keyword) {
         String redisKey = "chat:" + projectId;
 
-        Set<String> rawMessages = redisTemplate.opsForZSet().reverseRange(redisKey, 0, -1); //최신순
+        long now = System.currentTimeMillis();
+        long threeDaysAgo = now - Duration.ofDays(3).toMillis();
+
+        Set<String> rawMessages = redisTemplate.opsForZSet().reverseRange(redisKey, threeDaysAgo, now); //최신순
         if (rawMessages == null) return List.of();
 
         return rawMessages.stream()

--- a/src/main/java/com/evenly/evenide/service/ChatService.java
+++ b/src/main/java/com/evenly/evenide/service/ChatService.java
@@ -101,7 +101,7 @@ public class ChatService {
         long now = System.currentTimeMillis();
         long threeDaysAgo = now - Duration.ofDays(3).toMillis();
 
-        Set<String> rawMessages = redisTemplate.opsForZSet().reverseRange(redisKey, threeDaysAgo, now); //최신순
+        Set<String> rawMessages = redisTemplate.opsForZSet().reverseRangeByScore(redisKey, threeDaysAgo, now); //최신순
         if (rawMessages == null) return List.of();
 
         return rawMessages.stream()

--- a/src/main/java/com/evenly/evenide/service/ChatService.java
+++ b/src/main/java/com/evenly/evenide/service/ChatService.java
@@ -93,4 +93,24 @@ public class ChatService {
                 .filter(Objects::nonNull)
                 .toList();
     }
+
+    public List<ChatMessage> searchMessages(String projectId, String keyword) {
+        String redisKey = "chat:" + projectId;
+
+        Set<String> rawMessages = redisTemplate.opsForZSet().reverseRange(redisKey, 0, -1); //최신순
+        if (rawMessages == null) return List.of();
+
+        return rawMessages.stream()
+                .map(json -> {
+                    try {
+                        return objectMapper.readValue(json, ChatMessage.class);
+                    } catch (JsonProcessingException e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .filter(message -> message.getType() == ChatMessage.MessageType.MESSAGE)
+                .filter(message -> message.getContent() != null && message.getContent().contains(keyword))
+                .toList();
+    }
 }

--- a/src/main/java/com/evenly/evenide/service/ChatService.java
+++ b/src/main/java/com/evenly/evenide/service/ChatService.java
@@ -160,8 +160,8 @@ public class ChatService {
 
         if (centerIndex == -1) return List.of();
 
-        int from = Math.max(0, centerIndex - 3);
-        int to = Math.min(parsed.size(), centerIndex + 4);
+        int from = Math.max(0, centerIndex - 10);
+        int to = Math.min(parsed.size(), centerIndex + 11);
 
         return parsed.subList(from, to);
     }

--- a/src/main/java/com/evenly/evenide/service/ChatService.java
+++ b/src/main/java/com/evenly/evenide/service/ChatService.java
@@ -109,6 +109,7 @@ public class ChatService {
                     try {
                         return objectMapper.readValue(json, ChatMessage.class);
                     } catch (JsonProcessingException e) {
+                        log.error("Redis 메시지 역직렬화 실패", e);
                         return null;
                     }
                 })

--- a/src/main/resources/static/chat-diff-and-cursor.html
+++ b/src/main/resources/static/chat-diff-and-cursor.html
@@ -161,6 +161,7 @@
   function sendCursorPosition() {
     const line = getCaretLineNumber();
     const cursorMessage = {
+      type: "CODE_CURSOR",
       projectId,
       fileId,
       sender,


### PR DESCRIPTION
## 📌 작업 개요
- 메시지 검색 및 앞뒤 컨텍스트 메시지 조회 API 구현

---

## ✨ 주요 변경 사항
- 메시지 검색 API 구현
    - 로그인 사용자가 조회할 수 있는 3일 내의 메시지만 검색이 가능합니다. 
- 메시지 검색시 해당 메시지 기준 앞 뒤 10개씩 컨텍스트 조회 API 구현
    - 해당 메시지 기준 +-1일만 조회가 가능하므로 총 21개가 아닐 수 있습니다.
- 커서 웹소켓 test html 코드에서 type이 null로 들어가는 버그 발견해서 수정했습니다. 
    

---

## 🖼️ 화면(또는 기능) 미리 보기 (선택)
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능
아래 테스트 방법에 스크린샷 첨부했습니다.
---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 시나리오 기반 테스트 유무

- 메시지 컨텍스트 조회 테스트를 위해 실제 +-10개 -> 테스트 +-3개로 확인, 총 7개 메시지 리스트

| 메시지 조회 | 단건 메시지 기준 앞뒤 3개 조회 |
|----------|---------------|
|![image](https://github.com/user-attachments/assets/aa676f66-cf48-45d3-9cab-113dda46ea89)|![image](https://github.com/user-attachments/assets/ea502522-20d7-43de-abd7-71a3272617dd)|


|redis 저장 확인|
|--------------|
|![image](https://github.com/user-attachments/assets/71afe13c-c740-4525-9e6e-16f64f67e3f1)|


---

## 💬 기타 참고 사항
- 로그인 해야 가능합니다.

---

## 📎 관련 이슈 / 문서
- 기획안에는 없던 기능인데, 웹 ide 필수 구현 항목으로 쓰여있어 추가했습니다. 엑셀에 API 추가했고, 와이어프레임은 빠른 시일 내에 만들어서 프론트에 공유하겠습니다.
