### PR TITLE
채팅 메시지 필터링 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation 'org.apache.commons:commons-text:1.10.0'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/main/java/com/evenly/evenide/global/util/ChatMessageSanitizer.java
+++ b/src/main/java/com/evenly/evenide/global/util/ChatMessageSanitizer.java
@@ -1,0 +1,39 @@
+package com.evenly.evenide.global.util;
+
+import com.evenly.evenide.dto.ChatMessage;
+import org.apache.commons.text.StringEscapeUtils;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Pattern;
+
+@Component
+public class ChatMessageSanitizer {
+
+    private static final int MAX_LENGTH = 500;
+
+    private static final String[] FORBIDDEN_WORDS = {
+            "시발", "씨발", "ㅅㅂ", "ㅂㅅ", "병신", "미친", "존나", "ㅈㄴ",
+            "꺼져", "죽어", "멍청이", "개새끼", "좆", "섹스", "ㅅㄲ", "ㅗ", "ㅉ", "애미", "ㅂㅅ같은",
+
+            "fuck", "shit", "bitch", "asshole", "bastard", "dick", "pussy", "slut", "nigger", "fucker", "motherfucker"
+    };
+
+    public ChatMessage sanitize(ChatMessage chatMessage) {
+
+        String content = chatMessage.getContent();
+
+        for (String badWord : FORBIDDEN_WORDS) {
+            if (badWord.isBlank()) continue;
+            content = content.replaceAll("(?i)" + Pattern.quote(badWord), "*");
+        }
+
+        if (content.length() > MAX_LENGTH) {
+            content = content.substring(0, MAX_LENGTH);
+        }
+
+        content = StringEscapeUtils.escapeHtml4(content);
+
+        chatMessage.setContent(content);
+        return chatMessage;
+    }
+}

--- a/src/main/java/com/evenly/evenide/service/ChatService.java
+++ b/src/main/java/com/evenly/evenide/service/ChatService.java
@@ -2,6 +2,7 @@ package com.evenly.evenide.service;
 
 import com.evenly.evenide.config.security.JwtUtil;
 import com.evenly.evenide.dto.ChatMessage;
+import com.evenly.evenide.global.util.ChatMessageSanitizer;
 import com.evenly.evenide.global.util.RandomNameGenerator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -28,8 +29,10 @@ public class ChatService {
     private final RedisTemplate<String, String> redisTemplate;
     private final ObjectMapper objectMapper;
     private final JwtUtil jwtUtil;
+    private final ChatMessageSanitizer chatMessageSanitizer;
 
-    public void sendMessage(ChatMessage message) {
+    public void sendMessage(ChatMessage originalMessage) {
+        ChatMessage message = chatMessageSanitizer.sanitize(originalMessage);
         saveToRedis(message);
 
         String destination = "/topic/project/" + message.getProjectId();


### PR DESCRIPTION
## 📌 작업 개요
- 채팅 메시지 필터링 로직 구현

---

## ✨ 주요 변경 사항
- 채팅 메시지 필터링 로직 구현
    - 욕설 필터링
    - 길이 제한(500자)
    - HTML escape 

---

## 🖼️ 화면(또는 기능) 미리 보기 (선택)
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 -> 웹소켓으로 api 없음
   - 테스트 방법에 html 테스트 첨부


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN) -> html 테스트 진행
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 시나리오 기반 테스트 유무
- 글자 제한 테스트 편의를 위해 10자 이하로 진행(테스트 완료 후 500자로 다시 수정했습니다.)
  
HTML escape 테스트
| 전| 후| 
|---------------------|----------------------|
|![image](https://github.com/user-attachments/assets/00d3c8a9-a326-43f8-bffb-c464bffe2f30)| ![image](https://github.com/user-attachments/assets/b3e4ad29-281b-43d7-80c2-ab6c89da1296)|

욕설 및 길이 제한 테스트
| 전| 후| 
|---------------------|----------------------|
|![image](https://github.com/user-attachments/assets/71ea02af-e749-4d96-8026-7cf642bf2d75)| ![image](https://github.com/user-attachments/assets/804931da-a638-459b-afd3-3bc4aac19d70)|

---

## 💬 기타 참고 사항

---

## 📎 관련 이슈 / 문서
