### PR TITLE
AI API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,12 @@ configurations {
 
 repositories {
 	mavenCentral()
+	maven { url 'https://repo.spring.io/milestone' }
+	maven { url 'https://repo.spring.io/snapshot' }
+	maven {
+		name = 'Central Portal Snapshots'
+		url = 'https://central.sonatype.com/repository/maven-snapshots/'
+	}
 }
 
 dependencies {
@@ -32,6 +38,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
+	implementation platform("org.springframework.ai:spring-ai-bom:1.0.0-SNAPSHOT")
+	implementation 'org.springframework.ai:spring-ai-openai'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       SPRING_REDIS_PORT: ${REDIS_PORT}
       SPRING_REDIS_PASSWORD: ${REDIS_PASSWORD}
       RESET_URL: ${RESET_URL}
-
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
     ports:
       - "8080:8080"
     depends_on:

--- a/src/main/java/com/evenly/evenide/config/AiConfig.java
+++ b/src/main/java/com/evenly/evenide/config/AiConfig.java
@@ -1,0 +1,38 @@
+package com.evenly.evenide.config;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.openai.OpenAiChatModel;
+import org.springframework.ai.openai.OpenAiChatOptions;
+import org.springframework.ai.openai.api.OpenAiApi;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AiConfig {
+
+    @Value("${spring.ai.openai.api-key}")
+    private String apiKey;
+
+    @Bean
+    public ChatClient chatClient() {
+
+        OpenAiApi openAiApi = OpenAiApi.builder()
+                .apiKey(apiKey)
+                .build();
+
+        OpenAiChatOptions options = OpenAiChatOptions.builder()
+                .model("gpt-4o-mini")
+                .build();
+
+        OpenAiChatModel chatModel = OpenAiChatModel.builder()
+                .openAiApi(openAiApi)
+                .defaultOptions(options)
+                .build();
+
+        return ChatClient.builder(chatModel)
+                .defaultSystem("넌 친근하고 재밌는 튜터야. 항상 친구에게 설명하듯 말해줘. " +
+                        "쓸모 없는 말은 삼가고 대답은 최대한 간결하고 짧게 부탁할게.")
+                .build();
+    }
+}

--- a/src/main/java/com/evenly/evenide/controller/AiController.java
+++ b/src/main/java/com/evenly/evenide/controller/AiController.java
@@ -1,0 +1,30 @@
+package com.evenly.evenide.controller;
+
+import com.evenly.evenide.dto.AiRequest;
+import com.evenly.evenide.dto.AiResponse;
+import com.evenly.evenide.dto.JwtUserInfoDto;
+import com.evenly.evenide.service.AiService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/ai")
+public class AiController {
+
+    private final AiService aiService;
+
+    @PostMapping("/ask")
+    public ResponseEntity<AiResponse> ask(
+            @RequestBody AiRequest aiRequest,
+            @AuthenticationPrincipal JwtUserInfoDto userInfoDto
+    ) {
+        String result = aiService.ask(aiRequest);
+        return ResponseEntity.ok(new AiResponse(result));
+    }
+}

--- a/src/main/java/com/evenly/evenide/dto/AiRequest.java
+++ b/src/main/java/com/evenly/evenide/dto/AiRequest.java
@@ -1,0 +1,14 @@
+package com.evenly.evenide.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AiRequest {
+    private String mode;
+    private String prompt;
+    private String code;
+}

--- a/src/main/java/com/evenly/evenide/dto/AiResponse.java
+++ b/src/main/java/com/evenly/evenide/dto/AiResponse.java
@@ -1,0 +1,12 @@
+package com.evenly.evenide.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class AiResponse {
+    private String answer;
+}

--- a/src/main/java/com/evenly/evenide/service/AiService.java
+++ b/src/main/java/com/evenly/evenide/service/AiService.java
@@ -1,0 +1,36 @@
+package com.evenly.evenide.service;
+
+import com.evenly.evenide.dto.AiRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class AiService {
+
+    private final ChatClient chatClient;
+
+    public String ask(AiRequest request) {
+        String mode = Optional.ofNullable(request.getMode()).orElse("");
+        String prompt = request.getPrompt();
+        String code = Optional.ofNullable(request.getCode()).orElse("");
+
+        String finalPrompt = switch (mode) {
+            case "code-based" -> prompt + "\n\n[코드]\n" + code;
+            case "hint" -> "아래 질문에 대해 문제를 푸는 데 도움이 되는 '힌트'를 알려줘. " +
+                    "정답 코드나 직접적인 풀이 코드는 절대 제공하지 마! " +
+                    "대신 개념 설명, 풀이 아이디어, 비슷한 예제 코드 등은 자유롭게 제공해줘. " +
+                    "질문: " + prompt;
+            case "refactor" -> "다음 코드에 대해 리팩토링 부탁해. 왜 그렇게 수정해야 하는지 간단한 설명도 부탁할게!: \n\n" + code;
+            default -> prompt;
+        };
+
+        return chatClient.prompt()
+                .user(finalPrompt)
+                .call()
+                .content();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -33,3 +33,7 @@ spring.mail.password=${MAIL_PASSWORD}
 app.reset.url=${RESET_URL}
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+
+# AI
+spring.ai.openai.api-key: ${OPENAI_API_KEY}
+spring.ai.openai.chat.options.model: gpt-4o-mini


### PR DESCRIPTION
## 📌 작업 개요
- AI API 구현

---

## ✨ 주요 변경 사항
- AI API 구현
   - openAI API 연동
   - 일반 모드(default)
   - 코드 기반 모드(code-based)
   - 힌트 모드(hint)
   - 리팩토링 모드(refactor)
  
---

## 🖼️ 화면(또는 기능) 미리 보기 (선택)
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

|일반 챗봇|코드 기반|힌트|리팩토링|
|-------|-------|--------|------|
|<img width="1378" alt="image" src="https://github.com/user-attachments/assets/cd448806-e860-426f-8a4c-6c9792aedf15" />|<img width="1378" alt="image" src="https://github.com/user-attachments/assets/7e33aaa6-8990-4e27-81ed-23b41ebde0d2" />|<img width="1378" alt="image" src="https://github.com/user-attachments/assets/54b79966-c344-4b80-9c73-9fa58bb63c10" />|<img width="1378" alt="image" src="https://github.com/user-attachments/assets/ca1e45be-4935-444e-aad4-e3e12e28a41b" />|


---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리


---

## 💬 기타 참고 사항
- .env에 OPENAI_API_KEY= 추가 필요합니다. (과금) 서버에는 제 api 넣어두겠습니다.
- 모델은 4o-mini (가장 저렴)를 사용했습니다.
- 요청 dto에 mode, prompt, code가 있는데 prompt만 필수고 나머지는 nullable로 적용했습니다.
   - 모드에 따라 code가 ""로 들어갈 수도 있고 prompt도 ""로 넣을 수는 있습니다.
   - 포스트맨 API 문서 참고

---

## 📎 관련 이슈 / 문서
