### PR TITLE
비밀번호 링크 유효시간 변경

### DIFF
--- a/src/main/java/com/evenly/evenide/controller/MemoController.java
+++ b/src/main/java/com/evenly/evenide/controller/MemoController.java
@@ -1,0 +1,47 @@
+package com.evenly.evenide.controller;
+
+import com.evenly.evenide.dto.*;
+import com.evenly.evenide.global.response.MessageResponse;
+import com.evenly.evenide.service.MemoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/memo")
+public class MemoController {
+
+    private final MemoService memoService;
+
+    // 메모 생성
+    @PostMapping
+    public ResponseEntity<MemoCreateResponse> createMemo(@RequestBody MemoCreateRequest request, @RequestParam int lineNumber,
+                                                      @AuthenticationPrincipal JwtUserInfoDto userInfo) {
+        Long memoId = memoService.createMemo(request, Long.parseLong(userInfo.getUserId()), lineNumber);
+        return ResponseEntity.ok(
+                new MemoCreateResponse(memoId,"success")
+        );
+    }
+
+    @PostMapping("/lookup")
+    public ResponseEntity<MemoLookupResponse> lookupMemo(@RequestBody MemoLookupRequest request) {
+        return ResponseEntity.ok(memoService.lookup(request));
+    }
+
+    // 메모 수정
+    @PatchMapping("/{id}")
+    public ResponseEntity<MessageResponse> updateMemo(@PathVariable Long id, @AuthenticationPrincipal JwtUserInfoDto userInfo,
+                                           @RequestBody MemoUpdateRequest request) {
+        memoService.updateMemo(id, userInfo.getUserId(), request);
+        return ResponseEntity.ok(new MessageResponse("success"));
+    }
+
+    // 메모 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<MessageResponse> deleteMemo(@PathVariable Long id, @AuthenticationPrincipal JwtUserInfoDto userInfo) {
+        memoService.deleteMemo(id, userInfo.getUserId());
+        return ResponseEntity.ok(new MessageResponse("success"));
+    }
+}

--- a/src/main/java/com/evenly/evenide/dto/MemoCreateRequest.java
+++ b/src/main/java/com/evenly/evenide/dto/MemoCreateRequest.java
@@ -1,0 +1,6 @@
+package com.evenly.evenide.dto;
+
+public record MemoCreateRequest (
+    String fileId,
+    String content
+){}

--- a/src/main/java/com/evenly/evenide/dto/MemoCreateResponse.java
+++ b/src/main/java/com/evenly/evenide/dto/MemoCreateResponse.java
@@ -1,0 +1,6 @@
+package com.evenly.evenide.dto;
+
+public record MemoCreateResponse (
+   Long memoId,
+   String status
+) {}

--- a/src/main/java/com/evenly/evenide/dto/MemoLookupRequest.java
+++ b/src/main/java/com/evenly/evenide/dto/MemoLookupRequest.java
@@ -1,0 +1,6 @@
+package com.evenly.evenide.dto;
+
+public record MemoLookupRequest(
+        String fileId,
+        String codeSnapshot
+){}

--- a/src/main/java/com/evenly/evenide/dto/MemoLookupResponse.java
+++ b/src/main/java/com/evenly/evenide/dto/MemoLookupResponse.java
@@ -1,0 +1,8 @@
+package com.evenly.evenide.dto;
+
+import java.util.List;
+
+public record MemoLookupResponse (
+    int lineNumber,
+    List<MemoSimpleDto> memos
+){}

--- a/src/main/java/com/evenly/evenide/dto/MemoSimpleDto.java
+++ b/src/main/java/com/evenly/evenide/dto/MemoSimpleDto.java
@@ -1,0 +1,9 @@
+package com.evenly.evenide.dto;
+
+import java.time.LocalDateTime;
+
+public record MemoSimpleDto (
+    Long memoId,
+    String content,
+    LocalDateTime createdAt
+    ){}

--- a/src/main/java/com/evenly/evenide/dto/MemoUpdateRequest.java
+++ b/src/main/java/com/evenly/evenide/dto/MemoUpdateRequest.java
@@ -1,0 +1,5 @@
+package com.evenly.evenide.dto;
+
+public record MemoUpdateRequest (
+        String content
+){}

--- a/src/main/java/com/evenly/evenide/entity/Memo.java
+++ b/src/main/java/com/evenly/evenide/entity/Memo.java
@@ -1,0 +1,52 @@
+package com.evenly.evenide.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Memo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    private String content;
+
+    private String codeSnapshot;
+
+    private String fileId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public Memo(String content, String codeSnapshot, String fileId, User user) {
+        this.content = content;
+        this.codeSnapshot = codeSnapshot;
+        this.fileId = fileId;
+        this.user = user;
+    }
+
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    private void onUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+}

--- a/src/main/java/com/evenly/evenide/global/exception/ErrorCode.java
+++ b/src/main/java/com/evenly/evenide/global/exception/ErrorCode.java
@@ -21,9 +21,12 @@ public enum ErrorCode {
     CODE_EDIT_LOCKED(HttpStatus.FORBIDDEN,"코드 수정이 잠겨있습니다. 파일 주인만 수정이 가능합니다."),
 
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인 인증이 필요합니다."),
-    SAME_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 새 비밀번호가 동일합니다.");
+    SAME_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 새 비밀번호가 동일합니다."),
 
-
+    USER_NOT_FOUND_WHERE(HttpStatus.NOT_FOUND,"사용자를 찾을 수 없습니다."),
+    MEMO_NOT_FOUND(HttpStatus.NOT_FOUND,"메모를 찾을 수 없습니다."),
+    MEMO_NO_PERMISSION_PATCH(HttpStatus.FORBIDDEN,"수정 권한이 없습니다."),
+    MEMO_NO_PERMISSION_DELETE(HttpStatus.FORBIDDEN,"삭제 권한이 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/evenly/evenide/repository/MemoRepository.java
+++ b/src/main/java/com/evenly/evenide/repository/MemoRepository.java
@@ -1,0 +1,11 @@
+package com.evenly.evenide.repository;
+
+import com.evenly.evenide.entity.Memo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface MemoRepository extends JpaRepository<Memo, Long> {
+    List<Memo> findAllByFileIdAndCodeSnapshot(String fileId, String codeSnapshot);
+    List<Memo> findAllByFileId(String fileId);
+}

--- a/src/main/java/com/evenly/evenide/service/AuthService.java
+++ b/src/main/java/com/evenly/evenide/service/AuthService.java
@@ -203,7 +203,7 @@ public class AuthService {
         PasswordResetToken resetToken = PasswordResetToken.builder()
                 .user(user)
                 .token(token)
-                .expiration(LocalDateTime.now().plusMinutes(10))
+                .expiration(LocalDateTime.now().plusHours(2))
                 .build();
 
         passwordResetTokenRepository.save(resetToken);

--- a/src/main/java/com/evenly/evenide/service/EmailService.java
+++ b/src/main/java/com/evenly/evenide/service/EmailService.java
@@ -20,7 +20,7 @@ public class EmailService {
                 
                 아래 링크를 클릭하시면 비밀번호를 재설정 하실 수 있습니다.
                 %s
-                해당 링크는 10분 동안만 유효합니다.
+                해당 링크는 2시간 동안만 유효합니다.
                 감사합니다!
                 """.formatted(resetUrl));
         mailSender.send(message);

--- a/src/main/java/com/evenly/evenide/service/MemoCacheService.java
+++ b/src/main/java/com/evenly/evenide/service/MemoCacheService.java
@@ -1,0 +1,28 @@
+package com.evenly.evenide.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class MemoCacheService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    // redis에 저장
+    public void saveSnapShotLine(String fileId, String codeSnapshot, int lineNumber) {
+        String key = fileId + "::" + codeSnapshot;
+        redisTemplate.opsForValue().set(key,String.valueOf(lineNumber));
+    }
+
+    // redis에서 줄 번호 가져오는 부분
+    public Optional<Integer> getLineNumberBySnapshot(String fileId, String codeSnapshot) {
+        String key = fileId + "::" + codeSnapshot;
+        String result = redisTemplate.opsForValue().get(key);
+        return Optional.ofNullable(result).map(Integer::parseInt);
+    }
+
+}

--- a/src/main/java/com/evenly/evenide/service/MemoService.java
+++ b/src/main/java/com/evenly/evenide/service/MemoService.java
@@ -1,0 +1,101 @@
+package com.evenly.evenide.service;
+
+import com.evenly.evenide.dto.*;
+import com.evenly.evenide.entity.CodeFile;
+import com.evenly.evenide.entity.Memo;
+import com.evenly.evenide.entity.User;
+import com.evenly.evenide.global.exception.CustomException;
+import com.evenly.evenide.global.exception.ErrorCode;
+import com.evenly.evenide.repository.CodeFileRepository;
+import com.evenly.evenide.repository.MemoRepository;
+import com.evenly.evenide.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MemoService {
+
+    private final MemoRepository memoRepository;
+    private final UserRepository userRepository;
+    private final MemoCacheService memoCacheService;
+    private final CodeFileRepository codeFileRepository;
+
+    @Transactional
+    public Long createMemo(MemoCreateRequest request, Long userId, int lineNumber) {
+
+        CodeFile codeFile = codeFileRepository.findById(Long.valueOf(request.fileId()))
+                .orElseThrow(() -> new CustomException(ErrorCode.FILE_NOT_FOUND));
+
+        String[] lines = codeFile.getContent().split("\n");
+        if (lineNumber < 1 || lineNumber > lines.length) {
+            throw new CustomException(ErrorCode.MEMO_NOT_FOUND);
+        }
+        String snapshot = lines[lineNumber - 1].trim();
+
+        memoCacheService.saveSnapShotLine(request.fileId(), snapshot, lineNumber);
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND_WHERE));
+
+        Memo memo = new Memo(request.content(), snapshot, request.fileId(), user);
+        memoRepository.save(memo);
+        return memo.getId();
+    }
+
+
+    // 메모 목록 조회
+    @Transactional(readOnly = true)
+    public MemoLookupResponse lookup(MemoLookupRequest request) {
+        CodeFile codeFile = codeFileRepository.findById(Long.valueOf(request.fileId()))
+                .orElseThrow(() -> new CustomException(ErrorCode.FILE_NOT_FOUND));
+
+        String[] lines = codeFile.getContent().split("\n");
+        String snapshot = request.codeSnapshot().trim();
+
+        int matchedLine = -1;
+        for (int i = 0; i < lines.length; i++) {
+            if (lines[i].trim().equals(snapshot)) {
+                matchedLine = i + 1;
+                break;
+            }
+        }
+
+        List<Memo> memos = memoRepository.findAllByFileIdAndCodeSnapshot(
+                request.fileId(), snapshot
+        );
+
+        List<MemoSimpleDto> memoDtos = memos.stream()
+                .map(m -> new MemoSimpleDto(m.getId(), m.getContent(), m.getCreatedAt()))
+                .toList();
+
+        return new MemoLookupResponse(matchedLine, memoDtos);
+
+    }
+
+    // 메모 수정
+    @Transactional
+    public void updateMemo(Long memoId, String userId,MemoUpdateRequest request) {
+        Memo memo = memoRepository.findById(memoId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMO_NOT_FOUND));
+
+        if (!memo.getUser().getId().equals(Long.parseLong(userId))) {
+            throw new CustomException(ErrorCode.MEMO_NO_PERMISSION_PATCH);
+        }
+        memo.updateContent(request.content());
+    }
+
+    // 메모 삭제
+    @Transactional
+    public void deleteMemo(Long memoId, String userId) {
+        Memo memo = memoRepository.findById(memoId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMO_NOT_FOUND));
+        if (!memo.getUser().getId().equals(Long.parseLong(userId))) {
+            throw new CustomException(ErrorCode.MEMO_NO_PERMISSION_DELETE);
+        }
+        memoRepository.delete(memo);
+    }
+}


### PR DESCRIPTION
## 📌 작업 개요
- 비밀번호 재설정(reset-Password) 의 이메일링크의 유효시간을 10분 -> 2시간으로 늘렸습니다. (성민님 요청)

---

## 🖼️ 화면(또는 기능) 미리 보기 (선택)
> 포스트맨 요청 응답 스크린샷
<img width="960" alt="스크린샷 2025-04-22 오후 6 43 53" src="https://github.com/user-attachments/assets/07d1e1c0-8ddc-4dee-bcac-c8b5077ba4c4" />


---

