### PR TITLE
비밀번호 재설정 유효시간 변경

### DIFF
--- a/src/main/java/com/evenly/evenide/service/AuthService.java
+++ b/src/main/java/com/evenly/evenide/service/AuthService.java
@@ -203,7 +203,7 @@ public class AuthService {
         PasswordResetToken resetToken = PasswordResetToken.builder()
                 .user(user)
                 .token(token)
-                .expiration(LocalDateTime.now().plusMinutes(10))
+                .expiration(LocalDateTime.now().plusHours(2))
                 .build();
 
         passwordResetTokenRepository.save(resetToken);

--- a/src/main/java/com/evenly/evenide/service/EmailService.java
+++ b/src/main/java/com/evenly/evenide/service/EmailService.java
@@ -20,7 +20,7 @@ public class EmailService {
                 
                 아래 링크를 클릭하시면 비밀번호를 재설정 하실 수 있습니다.
                 %s
-                해당 링크는 10분 동안만 유효합니다.
+                해당 링크는 2시간 동안만 유효합니다.
                 감사합니다!
                 """.formatted(resetUrl));
         mailSender.send(message);


### PR DESCRIPTION
## 📌 작업 개요
- 비밀번호 재설정시 발송되는 링크의 토큰 유효시간을 10분에서 2시간으로 변경했습니다. (성민님 요청)

---

## 🖼️ 화면(또는 기능) 미리 보기 (선택)
> 포스트맨 요청 응답 스크린샷
<img width="960" alt="스크린샷 2025-04-22 오후 6 43 53" src="https://github.com/user-attachments/assets/9779d2b1-d0ec-404a-b98b-1200300b2853" />

