### PR TITLE
소셜 로그인 API 구현

### DIFF
--- a/src/main/java/com/evenly/evenide/controller/OAuthController.java
+++ b/src/main/java/com/evenly/evenide/controller/OAuthController.java
@@ -1,0 +1,25 @@
+package com.evenly.evenide.controller;
+
+import com.evenly.evenide.dto.OAuthTokenRequestDto;
+import com.evenly.evenide.dto.SignInResponse;
+import com.evenly.evenide.service.OAuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/auth/oauth")
+@RequiredArgsConstructor
+public class OAuthController {
+
+    private final OAuthService oAuthService;
+
+    @PostMapping("/{provider}")
+    public ResponseEntity<SignInResponse> oauthLogin(
+            @PathVariable String provider,
+            @RequestBody OAuthTokenRequestDto requestDto
+    ) {
+        SignInResponse response = oAuthService.loginWithOAuth(provider, requestDto.getAccessToken());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/evenly/evenide/dto/GoogleUserInfo.java
+++ b/src/main/java/com/evenly/evenide/dto/GoogleUserInfo.java
@@ -1,0 +1,23 @@
+package com.evenly.evenide.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GoogleUserInfo implements OAuthUserInfo {
+
+    private String sub;      // 고유 ID
+    private String email;
+    private String name;
+
+    @Override
+    public String getId() {
+        return sub;
+    }
+
+    @Override
+    public String getEmail() {
+        return email;
+    }
+}

--- a/src/main/java/com/evenly/evenide/dto/KakaoUserInfo.java
+++ b/src/main/java/com/evenly/evenide/dto/KakaoUserInfo.java
@@ -1,0 +1,34 @@
+package com.evenly.evenide.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class KakaoUserInfo implements OAuthUserInfo {
+
+    private Long id;
+    private KakaoAccount kakao_account;
+
+    @Override
+    public String getId() {
+        return String.valueOf(id);
+    }
+
+    @Override
+    public String getEmail() {
+        return kakao_account != null ? kakao_account.getEmail() : null;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class KakaoAccount {
+        private String email;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    public static class Profile {
+        private String nickname;
+    }
+}

--- a/src/main/java/com/evenly/evenide/dto/OAuthTokenRequestDto.java
+++ b/src/main/java/com/evenly/evenide/dto/OAuthTokenRequestDto.java
@@ -1,0 +1,10 @@
+package com.evenly.evenide.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OAuthTokenRequestDto {
+    private String accessToken;
+}

--- a/src/main/java/com/evenly/evenide/dto/OAuthUserInfo.java
+++ b/src/main/java/com/evenly/evenide/dto/OAuthUserInfo.java
@@ -1,0 +1,6 @@
+package com.evenly.evenide.dto;
+
+public interface OAuthUserInfo {
+    String getId();
+    String getEmail();
+}

--- a/src/main/java/com/evenly/evenide/entity/User.java
+++ b/src/main/java/com/evenly/evenide/entity/User.java
@@ -22,10 +22,10 @@ public class User {
     private Long id;
 
     @Email
-    @Column(nullable = false, unique = true)
+    @Column(nullable = true, unique = true)
     private String email;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String password;
 
     @Column(nullable = false, unique = true)

--- a/src/main/java/com/evenly/evenide/entity/User.java
+++ b/src/main/java/com/evenly/evenide/entity/User.java
@@ -53,4 +53,14 @@ public class User {
     public void updatePassword(String encodedPassword) {
         this.password = encodedPassword;
     }
+
+    public static User createSocialUser(String email, String nickname, String provider, String providerId) {
+        User user = new User();
+        user.email = email;
+        user.password = null;
+        user.nickname = nickname;
+        user.provider = provider;
+        user.providerId = providerId;
+        return user;
+    }
 }

--- a/src/main/java/com/evenly/evenide/global/exception/ErrorCode.java
+++ b/src/main/java/com/evenly/evenide/global/exception/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인 인증이 필요합니다."),
     SAME_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 새 비밀번호가 동일합니다."),
 
+    NICKNAME_GENERATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR,"닉네임 생성에 실패했습니다."),
     INVALID_OAUTH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 소셜 인증 토큰입니다."),
     UNSUPPORTED_PROVIDER(HttpStatus.UNAUTHORIZED, "지원하지 않는 소셜 로그인 방식입니다.");
 

--- a/src/main/java/com/evenly/evenide/global/exception/ErrorCode.java
+++ b/src/main/java/com/evenly/evenide/global/exception/ErrorCode.java
@@ -21,7 +21,10 @@ public enum ErrorCode {
     CODE_EDIT_LOCKED(HttpStatus.FORBIDDEN,"코드 수정이 잠겨있습니다. 파일 주인만 수정이 가능합니다."),
 
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "로그인 인증이 필요합니다."),
-    SAME_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 새 비밀번호가 동일합니다.");
+    SAME_PASSWORD(HttpStatus.BAD_REQUEST, "기존 비밀번호와 새 비밀번호가 동일합니다."),
+
+    INVALID_OAUTH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 소셜 인증 토큰입니다."),
+    UNSUPPORTED_PROVIDER(HttpStatus.UNAUTHORIZED, "지원하지 않는 소셜 로그인 방식입니다.");
 
 
 

--- a/src/main/java/com/evenly/evenide/global/oauth/GoogleOAuthClient.java
+++ b/src/main/java/com/evenly/evenide/global/oauth/GoogleOAuthClient.java
@@ -1,0 +1,37 @@
+package com.evenly.evenide.global.oauth;
+
+import com.evenly.evenide.dto.GoogleUserInfo;
+import com.evenly.evenide.global.exception.CustomException;
+import com.evenly.evenide.global.exception.ErrorCode;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class GoogleOAuthClient {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private static final String GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v3/userinfo";
+
+    public GoogleUserInfo getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<GoogleUserInfo> response = restTemplate.exchange(
+                    GOOGLE_USERINFO_URL,
+                    HttpMethod.GET,
+                    request,
+                    GoogleUserInfo.class
+            );
+            return response.getBody();
+        } catch (HttpClientErrorException e) {
+            throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/evenly/evenide/global/oauth/KakaoOAuthClient.java
+++ b/src/main/java/com/evenly/evenide/global/oauth/KakaoOAuthClient.java
@@ -1,0 +1,37 @@
+package com.evenly.evenide.global.oauth;
+
+import com.evenly.evenide.dto.KakaoUserInfo;
+import com.evenly.evenide.global.exception.CustomException;
+import com.evenly.evenide.global.exception.ErrorCode;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class KakaoOAuthClient {
+
+    private final RestTemplate restTemplate = new RestTemplate();
+    private static final String KAKAO_USERINFO_URL = "https://kapi.kakao.com/v2/user/me";
+
+    public KakaoUserInfo getUserInfo(String accessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(accessToken);
+        HttpEntity<Void> request = new HttpEntity<>(headers);
+
+        try {
+            ResponseEntity<KakaoUserInfo> response = restTemplate.exchange(
+                    KAKAO_USERINFO_URL,
+                    HttpMethod.GET,
+                    request,
+                    KakaoUserInfo.class
+            );
+            return response.getBody();
+        } catch (HttpClientErrorException e) {
+            throw new CustomException(ErrorCode.INVALID_OAUTH_TOKEN);
+        }
+    }
+}

--- a/src/main/java/com/evenly/evenide/global/util/SocialNameGenerator.java
+++ b/src/main/java/com/evenly/evenide/global/util/SocialNameGenerator.java
@@ -1,0 +1,36 @@
+package com.evenly.evenide.global.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+import java.util.function.Function;
+
+@Component
+public class SocialNameGenerator {
+
+    public String generate(String provider) {
+        String prefix = switch (provider.toUpperCase()) {
+            case "GOOGLE" -> "구그리_";
+            case "KAKAO" -> "코코아_";
+            default -> "그냥 사용자_";
+        };
+
+        int randomNum = new Random().nextInt(9000) + 1000;
+        return prefix + randomNum;
+    }
+
+    public String generateUnique(String provider, Function<String, Boolean> isDuplicate) {
+        String nickname;
+        int tryCount = 0;
+
+        do {
+            nickname = generate(provider);
+            tryCount++;
+            if (tryCount > 5) {
+                throw new RuntimeException("닉네임 생성 실패");
+            }
+        } while (isDuplicate.apply(nickname));
+
+        return nickname;
+    }
+}

--- a/src/main/java/com/evenly/evenide/global/util/SocialNameGenerator.java
+++ b/src/main/java/com/evenly/evenide/global/util/SocialNameGenerator.java
@@ -1,5 +1,7 @@
 package com.evenly.evenide.global.util;
 
+import com.evenly.evenide.global.exception.CustomException;
+import com.evenly.evenide.global.exception.ErrorCode;
 import org.springframework.stereotype.Component;
 
 import java.util.Random;
@@ -27,7 +29,7 @@ public class SocialNameGenerator {
             nickname = generate(provider);
             tryCount++;
             if (tryCount > 5) {
-                throw new RuntimeException("닉네임 생성 실패");
+                throw new CustomException(ErrorCode.NICKNAME_GENERATION_FAILED);
             }
         } while (isDuplicate.apply(nickname));
 

--- a/src/main/java/com/evenly/evenide/repository/UserRepository.java
+++ b/src/main/java/com/evenly/evenide/repository/UserRepository.java
@@ -15,4 +15,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 사용할 이메일 기준 조회
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByProviderAndProviderId(String provider, String providerId);
 }

--- a/src/main/java/com/evenly/evenide/service/AuthService.java
+++ b/src/main/java/com/evenly/evenide/service/AuthService.java
@@ -78,6 +78,7 @@ public class AuthService {
 
         // 가입되지 않은 사용자 일때
         User user = userRepository.findByEmail(signInDto.getEmail())
+                .filter(u -> u.getProvider().equals("local"))
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 비밀번호 검증 부분
@@ -191,6 +192,7 @@ public class AuthService {
     @Transactional
     public void sendResetEmail(String email) {
         User user = userRepository.findByEmail(email)
+                .filter(u -> u.getProvider().equals("local"))
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
 
         // 기존 토큰 삭제

--- a/src/main/java/com/evenly/evenide/service/OAuthService.java
+++ b/src/main/java/com/evenly/evenide/service/OAuthService.java
@@ -1,0 +1,57 @@
+package com.evenly.evenide.service;
+
+import com.evenly.evenide.config.security.JwtUtil;
+import com.evenly.evenide.dto.JwtUserInfoDto;
+import com.evenly.evenide.dto.OAuthUserInfo;
+import com.evenly.evenide.dto.SignInResponse;
+import com.evenly.evenide.entity.User;
+import com.evenly.evenide.global.exception.CustomException;
+import com.evenly.evenide.global.exception.ErrorCode;
+import com.evenly.evenide.global.oauth.GoogleOAuthClient;
+import com.evenly.evenide.global.oauth.KakaoOAuthClient;
+import com.evenly.evenide.global.util.SocialNameGenerator;
+import com.evenly.evenide.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OAuthService {
+
+    private final GoogleOAuthClient googleOAuthClient;
+    private final KakaoOAuthClient kakaoOAuthClient;
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final SocialNameGenerator socialNameGenerator;
+
+    @Transactional
+    public SignInResponse loginWithOAuth(String provider, String accessToken) {
+        OAuthUserInfo userInfo = switch (provider.toUpperCase()) {
+            case "GOOGLE" -> googleOAuthClient.getUserInfo(accessToken);
+            case "KAKAO" -> kakaoOAuthClient.getUserInfo(accessToken);
+            default -> throw new CustomException(ErrorCode.UNSUPPORTED_PROVIDER);
+        };
+
+        return userRepository.findByProviderAndProviderId(provider, userInfo.getId())
+                .map(this::createSignInResponse)
+                .orElseGet(() -> {
+                    String nickname = socialNameGenerator.generateUnique(provider, userRepository::existsByNickname);
+                    User newUser = User.createSocialUser(
+                            userInfo.getEmail(),
+                            nickname,
+                            provider,
+                            userInfo.getId()
+                    );
+                    userRepository.save(newUser);
+                    return createSignInResponse(newUser);
+                });
+    }
+
+    private SignInResponse createSignInResponse(User user) {
+        String[] tokens = jwtUtil.generateToken(new JwtUserInfoDto(user.getId().toString()));
+        return new SignInResponse(tokens[0], tokens[1], user.getId(), user.getNickname(), user.getProvider());
+    }
+
+
+}


### PR DESCRIPTION
## 📌 작업 개요
- 소셜 로그인 API 구현

---

## ✨ 주요 변경 사항
- 소셜 로그인 API 구현
   - 구글 : password null -> 닉네임 : 구그리_0000(숫자 4자리 랜덤)
   - 카카오 : password null, email null -> 닉네임 : 코코아_0000(숫자 4자리 랜덤)
- API 수정 POST /auth/social -> **POST /auth/oauth/{provider}** 

---

## 🖼️ 화면(또는 기능) 미리 보기 (선택)
> 포스트맨 요청 응답 스크린샷
- [x] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

|구글|카카오|
|---|------|
|![image](https://github.com/user-attachments/assets/93208608-f5af-4a8f-aaf4-2d5dc62d3732)|![image](https://github.com/user-attachments/assets/42b1c96a-e88a-407e-9ed1-5e453647cd51)|

|로그인 확인(프로젝트 생성)|잘못된 토큰|
|----------|------|
|![image](https://github.com/user-attachments/assets/20ba826c-6a1c-4533-a938-94a390f53182)|![image](https://github.com/user-attachments/assets/4f9b0789-8bdd-4e3f-a664-1cb815960aa7)|

---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 기능별 예외 케이스 고려
- [x] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [x] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
  - ex: ID 중복 시 예외 처리 발생

---

## 💬 기타 참고 사항
- 로그아웃은 일반 로그아웃과 동일한 API를 사용합니다.

---

## 📎 관련 이슈 / 문서
