### PR TITLE
리팩토링 및 웹 소켓 채팅 입장 메시지 타임스탬프 추가

### DIFF
--- a/src/main/java/com/evenly/evenide/service/ChatService.java
+++ b/src/main/java/com/evenly/evenide/service/ChatService.java
@@ -31,6 +31,11 @@ public class ChatService {
     private final JwtUtil jwtUtil;
     private final ChatMessageSanitizer chatMessageSanitizer;
 
+    //클래스 변수
+    private static final long ONE_SECOND = 1000L;
+    private static final long ONE_MINUTE = ONE_SECOND * 60;
+    private static final long ONE_HOUR = ONE_MINUTE * 60;
+
     public void sendMessage(ChatMessage originalMessage) {
         ChatMessage message = chatMessageSanitizer.sanitize(originalMessage);
         saveToRedis(message);
@@ -79,8 +84,8 @@ public class ChatService {
         long now = Instant.now().toEpochMilli();
 
         long threshold = isAnon
-                ? now - 1000L * 60 * 60 * 24
-                : now - 1000L * 60 * 60 * 24 * 3;
+                ? now - ONE_HOUR * 24
+                : now - ONE_HOUR * 24 * 3;
         Set<String> jsonSet = redisTemplate.opsForZSet().rangeByScore(key, threshold, now);
         List<String> jsonList = new ArrayList<>(jsonSet);
 
@@ -130,17 +135,18 @@ public class ChatService {
 
         long now = System.currentTimeMillis();
         long threeDaysAgo = now - Duration.ofDays(3).toMillis(); // 3일을 넘지 않음.
-        long margin = Duration.ofHours(24).toMillis(); // 검색한 메시지의 +-1일 메시지
+        long oneDayMargin = Duration.ofHours(24).toMillis(); // 검색한 메시지의 +-1일 메시지
+        long fromTimestamp = Math.max(threeDaysAgo, center - oneDayMargin);
 
         Set<ZSetOperations.TypedTuple<String>> messagesWithScore =
                 redisTemplate.opsForZSet().rangeByScoreWithScores(
                         redisKey,
-                        Math.max(threeDaysAgo, center - margin),
-                        center + margin
+                        fromTimestamp,
+                        center + oneDayMargin
                 );
         if (messagesWithScore == null) return List.of();
 
-        List<ChatMessage> parsed = messagesWithScore.stream()
+        List<ChatMessage> parsedMessage = messagesWithScore.stream()
                 .sorted(Comparator.comparingDouble(tuple ->
                         tuple.getScore() != null ? tuple.getScore() : 0.0 // null 방지용 0.0
                 ))
@@ -156,16 +162,20 @@ public class ChatService {
                 .filter(message -> message.getType() == ChatMessage.MessageType.MESSAGE)
                 .toList();
 
-        int centerIndex = IntStream.range(0, parsed.size())
-                .filter(i -> parsed.get(i).getTimestamp().equals(LocalDateTime.parse(timestampStr)))
+        int centerIndex = IntStream.range(0, parsedMessage.size())
+                .filter(i -> parsedMessage.get(i).getTimestamp().equals(LocalDateTime.parse(timestampStr)))
                 .findFirst()
                 .orElse(-1);
 
-        if (centerIndex == -1) return List.of();
+        if (isEmptyMessage(centerIndex)) return List.of();
 
         int from = Math.max(0, centerIndex - 10);
-        int to = Math.min(parsed.size(), centerIndex + 11);
+        int to = Math.min(parsedMessage.size(), centerIndex + 11);
 
-        return parsed.subList(from, to);
+        return parsedMessage.subList(from, to);
+    }
+
+    private boolean isEmptyMessage(int centerIndex) {
+        return centerIndex == -1;
     }
 }

--- a/src/main/java/com/evenly/evenide/service/ChatService.java
+++ b/src/main/java/com/evenly/evenide/service/ChatService.java
@@ -50,7 +50,15 @@ public class ChatService {
             message.setNickname(RandomNameGenerator.generateNickname());
         }
 
+        message.setType(ChatMessage.MessageType.JOIN);
         message.setContent(message.getNickname() + "님이 입장했습니다.");
+
+        if (message.getTimestamp() == null) {
+            message.setTimestamp(LocalDateTime.now());
+        }
+
+        saveToRedis(message);
+
         String destination = "/topic/project/" + message.getProjectId();
         messageSendingOperations.convertAndSend(destination, message);
     }


### PR DESCRIPTION
## 📌 작업 개요
- 리팩토링 및 웹 소켓 채팅 입장 메시지 타임스탬프 추가

---

## ✨ 주요 변경 사항
- 코드 리뷰 후 리팩토링
   - 클래스 변수 등 도입
- 웹 소켓 채팅 입장 메시지 타임스탬프 추가 + redis 저장(history 조회 시 출력)

---

## 🖼️ 화면(또는 기능) 미리 보기 (선택)
> 포스트맨 요청 응답 스크린샷
- [ ] API 문서(요청, 응답)와 일치하는지 확인 - 필요시 API 문서 수정 가능

---

## ✅ 작업 체크리스트
- [ ] API 테스트 완료 (POSTMAN)
- [ ] 기능별 예외 케이스 고려
- [ ] log.info / 불필요한 주석 제거
- [x] 변수명, 클래스명, 메서드명 의미있게 작성
- [ ] 반복 코드 메서드로 분리

---

## 📂 테스트 방법
- [x] 테스트 코드 작성
- [ ] 시나리오 기반 테스트 유무
  - 웹 소켓 채팅 입장 메시지 타임스탬프 추가 + redis 저장 (type join)
 
|html 채팅|redis |
|---------|------|
|![image](https://github.com/user-attachments/assets/cea31b60-e922-4719-9f93-8f6242e9890d)|![image](https://github.com/user-attachments/assets/2373c56f-8680-444e-9f7b-cf37fbaed1d4)|


---

## 💬 기타 참고 사항
- 오늘 퍼실님과 코드 리뷰 진행하고 변수 및 클래스 등 리팩토링 진행했습니다.
- 요청이 들어와서 join에도 타임스탬프를 추가했습니다.

---

## 📎 관련 이슈 / 문서
![image](https://github.com/user-attachments/assets/b49f4b9e-360c-43fd-b4e5-7400c494606b)
위 스크린샷과 같이 입장 메시지 출력 후 타임스탬프가 출력되는 문제.

