### PR TITLE
메모 기능 관련 심각한 버그 수정

### DIFF
--- a/src/main/java/com/evenly/evenide/entity/Memo.java
+++ b/src/main/java/com/evenly/evenide/entity/Memo.java
@@ -16,14 +16,16 @@ public class Memo {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long memoId;
 
-    private Long fileId;
-
     private String memo;
 
     @ManyToOne(fetch = FetchType.LAZY)
     private User user;
 
     private LocalDateTime createdAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "file_id")
+    private CodeFile codeFile;
 
     @PrePersist
     public void prePersist() {

--- a/src/main/java/com/evenly/evenide/global/exception/ErrorCode.java
+++ b/src/main/java/com/evenly/evenide/global/exception/ErrorCode.java
@@ -29,7 +29,8 @@ public enum ErrorCode {
 
     MEMO_NOT_FOUND(HttpStatus.NOT_FOUND,"존재하지 않는 메모입니다."),
     MEMO_NO_PERMISSION_PATCH(HttpStatus.FORBIDDEN,"수정 권한이 없습니다."),
-    MEMO_NO_PERMISSION_DELETE(HttpStatus.FORBIDDEN,"삭제 권한이 없습니다.");
+    MEMO_NO_PERMISSION_DELETE(HttpStatus.FORBIDDEN,"삭제 권한이 없습니다."),
+    INVALID_MEMO_ACCESS(HttpStatus.FORBIDDEN,"해당 파일에 속하지 않은 메모입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/evenly/evenide/repository/MemoRepository.java
+++ b/src/main/java/com/evenly/evenide/repository/MemoRepository.java
@@ -2,6 +2,7 @@ package com.evenly.evenide.repository;
 
 import com.evenly.evenide.entity.Memo;
 import com.evenly.evenide.entity.User;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,11 +13,13 @@ import java.util.Optional;
 
 @Repository
 public interface MemoRepository extends JpaRepository<Memo, Long> {
-    @Query("SELECT m FROM Memo m JOIN FETCH m.user WHERE m.fileId IN :fileIds")
-    List<Memo> findAllByFileIdInFetchUser(@Param("fileIds") List<Long> fileIds);
-
-    @Query("SELECT m FROM Memo m JOIN FETCH m.user WHERE m.memoId = :memoId")
-    Optional<Memo> findWithUserByMemoId(@Param("memoId") Long memoId);
 
     Optional<Memo> findByMemoIdAndUser(Long memoId, User user);
+
+    @EntityGraph(attributePaths = "user")
+    List<Memo> findAllByCodeFile_IdIn(List<Long> fileIds);
+
+    @EntityGraph(attributePaths = "user")
+    Optional<Memo> findByMemoId(Long memoId);
+
 }


### PR DESCRIPTION
## 📌 작업 개요
- 메모 기능에서 다른 파일의 memoId로도 수정/삭제가 가능했던 문제 수정 
---

## ✨ 주요 변경 사항
- 기존 쿼리 제거
- fileId 와 memoId가 일치하는지 확인하는 로직 생성
---

## 🖼️ 화면(또는 기능) 미리 보기 (선택)
> 포스트맨 요청 응답 스크린샷
수정 (해당 위치에 존재하는 memoId가 아닐때),수정 (해당 위치에 존재하는 memoId가 맞을때),수정 후 조회


| 수정<br>(해당 위치에 존재하는 memoId가 아닐때) | 수정<br>(해당 위치에 존재하는 memoId가 맞을때) | 수정 후 조회 |
|-------|-------|-------|
| ![수정 테스트1](https://github.com/user-attachments/assets/59a252d5-31ea-47f5-8a99-b92f4523540c) | ![수정테스트2](https://github.com/user-attachments/assets/7d83ed26-e371-4116-9b50-733aeb30b069) | ![수정테스트 확인](https://github.com/user-attachments/assets/30eda839-5d6d-4dd3-99ea-6b1e908b3ab4) |



| 삭제<br>(해당 위치에 존재하는 memoId가 아닐때) | 삭제<br>(해당 위치에 존재하는 memoId가 맞을때) | 삭제 후 조회 |
|-------|-------|-------|
| ![삭제 테스트1](https://github.com/user-attachments/assets/3b1d337d-2f99-4b60-9bc9-f57a024ed3dc) | ![삭제 테스트2](https://github.com/user-attachments/assets/42a8da6d-ac72-401c-b8e2-0dceead3703f) | ![삭제테스트 확인](https://github.com/user-attachments/assets/5010e965-97eb-48af-9a6b-ec71fe923a91) |



---

## ✅ 작업 체크리스트
- [x] API 테스트 완료 (POSTMAN)
- [x] 메모 수정/삭제 예외 확인 및 정상 동작 확인

---

## 📎 관련 이슈 / 문서
- close #37 

